### PR TITLE
var substitution cleanup

### DIFF
--- a/openmaptiles/sql.py
+++ b/openmaptiles/sql.py
@@ -260,6 +260,16 @@ def to_sql(sql: str, layer: Layer, nodata: bool):
     # replace FIELD_MAPPING:<field_name> param with the generated SQL CASE statement
     sql = re.sub(r'( *)%%\s*FIELD_MAPPING\s*:\s*([a-zA-Z0-9_-]+)\s*%%', field_map, sql)
 
+    def var_substitution(match):
+        var_name = match.group(1)
+        value = layer.vars.get(var_name)
+        if value is None:
+            raise ValueError(f'Variable {var_name} is not defined on the layer')
+        return str(value)
+
+    # replace %%VAR:<variable_name>%% with the corresponding layer variable
+    sql = re.sub(r'%%\s*VAR\s*:\s*([a-zA-Z0-9_-]+)\s*%%', var_substitution, sql)
+
     # inject 'WITH NO DATA' for the materialized views
     if nodata:
         sql = re.sub(

--- a/openmaptiles/tileset.py
+++ b/openmaptiles/tileset.py
@@ -10,7 +10,6 @@ from deprecated import deprecated
 
 from .utils import print_err
 
-
 GetEnv = NewType('GetEnv', Callable[[str, Optional[str]], Optional[str]])
 
 
@@ -85,7 +84,6 @@ class Layer:
     imposm_mappings: List[dict]
     schemas: List[str]
     fields: List[Field]
-    vars: Dict[str, Any]
 
     @staticmethod
     def parse(layer_source: Union[str, Path, ParsedData]) -> 'Layer':
@@ -104,7 +102,8 @@ class Layer:
         """
         self.tileset = tileset
         self.index = index
-        self.overrides = overrides
+        self.overrides = overrides if overrides is not None else {}
+        self._getenv = self.tileset.getenv if self.tileset else os.getenv
 
         if isinstance(layer_source, ParsedData):
             self.filename = layer_source.path
@@ -173,41 +172,23 @@ class Layer:
             # If 'yes', we will need to generate a wrapper query that includes
             # osm_id column twice - once for feature_id, and once as an attribute
             raise ValueError('key_field_as_attribute=yes is not yet implemented')
-        self.vars = self.__init_vars()
 
-    def __init_vars(self):
-        vars_layer = self.definition['layer'].get('vars', {})
+        self._vars = self.definition['layer'].get('vars', {})
+        if self.tileset:
+            for name, value in self.tileset.overrides.items():
+                if name in self._vars:
+                    self._vars[name] = value
+        for name, value in self.overrides.get('vars', {}).items():
+            if name not in self._vars:
+                raise ValueError(f'Layer override variable "{name}" is not defined in the layer')
+            self._vars[name] = value
+        for name in self._vars.keys():
+            self._vars[name] = self.getenv(f'OMT_VAR_{name}', self._vars[name])
 
-        self.__vars_overrides_tileset(vars_layer)
-        self.__vars_overrides_layer(vars_layer)
-        self.__vars_overrides_environment(vars_layer)
-
-        return vars_layer
-
-    def __vars_overrides_tileset(self, vars_layer):
-        tileset_overrides_vars = self.tileset.overrides.get('vars', {}) if self.tileset else {}
-
-        for name, value in tileset_overrides_vars.items():
-            if name in vars_layer:
-                vars_layer[name] = value
-
-    def __vars_overrides_layer(self, vars_layer):
-        layer_overrides = self.overrides if self.overrides else {}
-        layer_overrides_vars = layer_overrides.get('vars', {})
-
-        for name, value in layer_overrides_vars.items():
-            if name in vars_layer:
-                vars_layer[name] = value
-            else:
-                raise ValueError(f'Variable {name} overrided is not defined in the layer')
-
-    def __vars_overrides_environment(self, vars_layer):
-        getenv = self.tileset.getenv if self.tileset else os.getenv
-
-        for name in vars_layer.keys():
-            env_var_value = getenv(f'OMT_VAR_{name}', None)
-            if env_var_value is not None:
-                vars_layer[name] = env_var_value
+    def getenv(self, name: str, default: str = '') -> str:
+        # Allow empty env var to be the same as unset.
+        value = self._getenv(name, '')
+        return value if value != '' else default
 
     def get_fields(self) -> List[str]:
         """Get a list of field names this layer generates.
@@ -281,9 +262,7 @@ class Layer:
             if min_val is not None:
                 min_size = min_val
         # Override with ENV variables
-        # Allow empty env var to be the same as unset.
-        getenv = self.tileset.getenv if self.tileset else os.getenv
-        tbs = getenv('TILE_BUFFER_SIZE', '')
+        tbs = self.getenv('TILE_BUFFER_SIZE')
         val = assert_int(tbs if tbs != '' else None, 'TILE_BUFFER_SIZE env var', min_val=0)
         if val is not None:
             size = val
@@ -343,6 +322,9 @@ class Layer:
         else:
             fields = tag_fields_to_sql(Tileset.auto_language_fields)
         return self.raw_query.format(name_languages=(', '.join(fields)))
+
+    def get_var(self, name: str) -> str:
+        return str(self._vars[name])
 
     @property
     @deprecated(version='5.4.0', reason='use requires_layers property instead')

--- a/openmaptiles/tileset.py
+++ b/openmaptiles/tileset.py
@@ -173,19 +173,23 @@ class Layer:
             # osm_id column twice - once for feature_id, and once as an attribute
             raise ValueError('key_field_as_attribute=yes is not yet implemented')
 
+        self._vars = self._assemble_vars()
+
+    def _assemble_vars(self) -> Dict[str, str]:
         # Compute layer variables including the override logic.
         # Priority order (last wins):  layer, tileset global, tileset per layer, env vars
-        self._vars = self.definition['layer'].get('vars', {})
+        result = self.definition['layer'].get('vars', {})
         if self.tileset:
             for name, value in self.tileset.overrides.get('vars', {}).items():
-                if name in self._vars:
-                    self._vars[name] = value
+                if name in result:
+                    result[name] = value
         for name, value in self.overrides.get('vars', {}).items():
-            if name not in self._vars:
+            if name not in result:
                 raise ValueError(f'Layer override variable "{name}" is not defined in the layer')
-            self._vars[name] = value
-        for name in self._vars.keys():
-            self._vars[name] = self.getenv(f'OMT_VAR_{name}', self._vars[name])
+            result[name] = value
+        for name in result.keys():
+            result[name] = self.getenv(f'OMT_VAR_{name}', result[name])
+        return result
 
     def getenv(self, name: str, default: str = '') -> str:
         # Allow empty env var to be the same as unset.
@@ -326,6 +330,8 @@ class Layer:
         return self.raw_query.format(name_languages=(', '.join(fields)))
 
     def get_var(self, name: str) -> str:
+        if name not in self._vars:
+            raise ValueError(f'Variable {name} does not exist in layer {self.id}')
         return str(self._vars[name])
 
     @property

--- a/openmaptiles/tileset.py
+++ b/openmaptiles/tileset.py
@@ -173,9 +173,11 @@ class Layer:
             # osm_id column twice - once for feature_id, and once as an attribute
             raise ValueError('key_field_as_attribute=yes is not yet implemented')
 
+        # Compute layer variables including the override logic.
+        # Priority order (last wins):  layer, tileset global, tileset per layer, env vars
         self._vars = self.definition['layer'].get('vars', {})
         if self.tileset:
-            for name, value in self.tileset.overrides.items():
+            for name, value in self.tileset.overrides.get('vars', {}).items():
                 if name in self._vars:
                     self._vars[name] = value
         for name, value in self.overrides.get('vars', {}).items():

--- a/tests/python/test_helpers.py
+++ b/tests/python/test_helpers.py
@@ -1,0 +1,40 @@
+from typing import List, Union, Dict
+from dataclasses import dataclass
+from pathlib import Path
+
+from openmaptiles.tileset import ParsedData
+
+
+@dataclass
+class Case:
+    id: str
+    query: str
+    reqs: Union[str, List[str], Dict[str, Union[str, List[str]]]] = None
+
+
+def parsed_data(layers: Union[Case, List[Case]]):
+    return ParsedData(dict(
+        tileset=(dict(
+            attribution='test_attribution',
+            bounds='test_bounds',
+            center='test_center',
+            defaults=dict(srs='test_srs', datasource=dict(srid='test_datasource')),
+            id='id1',
+            layers=[
+                dict(file=ParsedData(dict(
+                    layer=dict(
+                        buffer_size='10',
+                        datasource=dict(query='test_query'),
+                        id=v.id,
+                        fields={},
+                        requires=[v.reqs] if isinstance(v.reqs, str) else v.reqs or []
+                    ),
+                    schema=[ParsedData(v.query, Path(v.id + '_s.yaml'))] if v.query else [],
+                ), Path(f'./{v.id}.yaml'))) for v in ([layers] if isinstance(layers, Case) else layers)
+            ],
+            maxzoom='test_maxzoom',
+            minzoom='test_minzoom',
+            name='test_name',
+            pixel_scale='test_pixel_scale',
+            version='test_version',
+        ))), Path('./tileset.yaml'))

--- a/tests/python/test_sql.py
+++ b/tests/python/test_sql.py
@@ -1,18 +1,8 @@
-import warnings
-from dataclasses import dataclass
-from pathlib import Path
-from typing import List, Union, Dict, Optional
+from typing import List, Union, Dict
 from unittest import main, TestCase
+from tests.python.test_helpers import Case, parsed_data
 
 from openmaptiles.sql import collect_sql, sql_assert_table, sql_assert_func
-from openmaptiles.tileset import ParsedData, Tileset
-
-
-@dataclass
-class Case:
-    id: str
-    query: str
-    reqs: Union[str, List[str], Dict[str, Union[str, List[str]]]] = None
 
 
 def expected_sql(case: Case):
@@ -32,34 +22,6 @@ def expected_sql(case: Case):
 DO $$ BEGIN RAISE NOTICE 'Finished layer {case.id}'; END$$;
 """
     return result
-
-
-def parsed_data(layers: Union[Case, List[Case]]):
-    return ParsedData(dict(
-        tileset=(dict(
-            attribution='test_attribution',
-            bounds='test_bounds',
-            center='test_center',
-            defaults=dict(srs='test_srs', datasource=dict(srid='test_datasource')),
-            id='id1',
-            layers=[
-                dict(file=ParsedData(dict(
-                    layer=dict(
-                        buffer_size='10',
-                        datasource=dict(query='test_query'),
-                        id=v.id,
-                        fields={},
-                        requires=[v.reqs] if isinstance(v.reqs, str) else v.reqs or []
-                    ),
-                    schema=[ParsedData(v.query, Path(v.id + '_s.yaml'))] if v.query else [],
-                ), Path(f'./{v.id}.yaml'))) for v in ([layers] if isinstance(layers, Case) else layers)
-            ],
-            maxzoom='test_maxzoom',
-            minzoom='test_minzoom',
-            name='test_name',
-            pixel_scale='test_pixel_scale',
-            version='test_version',
-        ))), Path('./tileset.yaml'))
 
 
 class SqlTestCase(TestCase):
@@ -136,100 +98,6 @@ $$ LANGUAGE SQL IMMUTABLE;
         self._test('a18', [c12], dict(c12=[c12]))
         self._test('a19', [c13], dict(c13=[c13]))
         self._test('a20', [c14], dict(c14=[c14]))
-
-    def _ts_parse(self, reqs, expected_layers, expected_tables, expected_funcs, extra_cases=None):
-        cases = [] if not extra_cases else list(extra_cases)
-        cases.append(Case('my_id', 'my_query;', reqs=reqs))
-        ts = Tileset(parsed_data(cases))
-        self.assertEqual(ts.attribution, 'test_attribution')
-        self.assertEqual(ts.bounds, 'test_bounds')
-        self.assertEqual(ts.center, 'test_center')
-        self.assertEqual(ts.defaults, dict(srs='test_srs', datasource=dict(srid='test_datasource')))
-        self.assertEqual(ts.id, 'id1')
-        self.assertEqual(ts.maxzoom, 'test_maxzoom')
-        self.assertEqual(ts.minzoom, 'test_minzoom')
-        self.assertEqual(ts.name, 'test_name')
-        self.assertEqual(ts.pixel_scale, 'test_pixel_scale')
-        self.assertEqual(ts.version, 'test_version')
-
-        self.assertEqual(len(ts.layers), len(cases))
-        layer = ts.layers_by_id['my_id']
-        self.assertEqual(layer.id, 'my_id')
-        self.assertEqual(layer.requires_layers, expected_layers)
-        self.assertEqual(layer.requires_tables, expected_tables)
-        self.assertEqual(layer.requires_functions, expected_funcs)
-        self.assertEqual(layer.buffer_size, 10)
-
-        # This test can be deleted once we remove the deprecated property in some future version
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=DeprecationWarning)
-            self.assertEqual(layer.requires, expected_layers)
-
-    def test_ts_parse(self):
-        extra = [Case('c1', 'SELECT 1;')]
-
-        self._ts_parse(None, [], [], [])
-        self._ts_parse([], [], [], [])
-        self._ts_parse({}, [], [], [])
-        self._ts_parse('c1', ['c1'], [], [], extra)
-        self._ts_parse(['c1'], ['c1'], [], [], extra)
-        self._ts_parse(dict(layers='c1'), ['c1'], [], [], extra)
-        self._ts_parse(dict(layers=['c1']), ['c1'], [], [], extra)
-        self._ts_parse(dict(tables='a'), [], ['a'], [])
-        self._ts_parse(dict(tables=['a', 'b']), [], ['a', 'b'], [])
-        self._ts_parse(dict(functions='x'), [], [], ['x'])
-        self._ts_parse(dict(functions=['x', 'y']), [], [], ['x', 'y'])
-        self._ts_parse(dict(layers=['c1'], tables=['a', 'b'], functions=['x', 'y']),
-                       ['c1'], ['a', 'b'], ['x', 'y'], extra)
-
-    def _ts_overrides(self, expected_layer: dict,
-                      layer: Optional[dict] = None,
-                      override_ts: Optional[dict] = None,
-                      override_layer: Optional[dict] = None,
-                      env: Optional[dict] = None):
-        data = parsed_data([Case('my_id', 'my_query;')])
-
-        ts_data = data.data['tileset']
-        if override_ts is not None:
-            ts_data['overrides'] = override_ts
-        if layer is not None:
-            ts_data['layers'][0]['file'].data['layer'].update(layer)
-        if override_layer is not None:
-            ts_data['layers'][0].update(override_layer)
-
-        ts = Tileset(data, getenv=env.get if env else None)
-        for k in expected_layer.keys():
-            self.assertEqual(getattr(ts.layers_by_id['my_id'], k), expected_layer[k])
-
-    def test_overrides(self):
-        buf_0 = dict(buffer_size=0)
-        buf_1 = dict(buffer_size=1)
-        buf_2 = dict(buffer_size=2)
-        buf_3 = dict(buffer_size=3)
-        min_1 = dict(min_buffer_size=1)
-        min_2 = dict(min_buffer_size=2)
-        min_3 = dict(min_buffer_size=3)
-
-        self._ts_overrides(buf_2, buf_2)
-        self._ts_overrides(buf_0, buf_2, override_ts=buf_0)
-        self._ts_overrides(buf_1, buf_2, override_ts=buf_1)
-        self._ts_overrides(buf_3, buf_2, override_ts=buf_3)
-        self._ts_overrides(buf_1, min_1 | buf_2, override_ts=buf_0)
-        self._ts_overrides(buf_1, buf_2, override_layer=buf_1)
-        self._ts_overrides(buf_2, min_2 | buf_3, override_layer=buf_1)
-        self._ts_overrides(buf_3, min_1 | buf_2, override_layer=min_3)
-        self._ts_overrides(buf_3, min_1 | buf_2, override_layer=min_2 | buf_3, override_ts=buf_0)
-
-        env_0 = dict(TILE_BUFFER_SIZE='0')
-        env_2 = dict(TILE_BUFFER_SIZE='2')
-        self._ts_overrides(buf_2, min_1 | buf_2, override_layer=min_2 | buf_3, override_ts=buf_0, env=env_0)
-        self._ts_overrides(buf_2, buf_1, env=env_2)
-        self._ts_overrides(buf_2, min_2 | buf_3, env=env_0)
-        self._ts_overrides(buf_2, min_1 | buf_3, override_ts=buf_0, env=env_2)
-        self._ts_overrides(buf_2, buf_2, dict(TILE_BUFFER_SIZE=''))
-
-        # str parsing
-        self._ts_overrides(dict(buffer_size=2), dict(buffer_size='2'))
 
 
 if __name__ == '__main__':

--- a/tests/python/test_sql.py
+++ b/tests/python/test_sql.py
@@ -101,15 +101,15 @@ $$ LANGUAGE SQL IMMUTABLE;
         self._test('a20', [c14], dict(c14=[c14]))
 
     def test_var_substitution(self):
-        vars = dict(vars=dict(var_substitution_1=14, var_substitution_2='az'))
+        variables = dict(vars=dict(var_substitution_1=14, var_substitution_2='az'))
         data = parsed_data(Case('my_id', ''))
-        data.data['tileset']['layers'][0]['file'].data['layer'].update(vars)
+        data.data['tileset']['layers'][0]['file'].data['layer'].update(variables)
         ts = Tileset(data)
         layer = ts.layers_by_id['my_id']
 
         self.assertEqual(to_sql('SELECT * from test where zoom > %%VAR:var_substitution_1%%', layer, False), 'SELECT * from test where zoom > 14')
         self.assertEqual(to_sql("SELECT * from test where zoom > '%%VAR:var_substitution_2%%'", layer, False), "SELECT * from test where zoom > 'az'")
-        self.assertRaises(ValueError, to_sql, 'SELECT * from test where zoom > %%VAR:var_substitution_3%%', layer, False)
+        self.assertRaises(KeyError, to_sql, 'SELECT * from test where zoom > %%VAR:var_substitution_3%%', layer, False)
 
 
 if __name__ == '__main__':

--- a/tests/python/test_sql.py
+++ b/tests/python/test_sql.py
@@ -109,7 +109,7 @@ $$ LANGUAGE SQL IMMUTABLE;
 
         self.assertEqual(to_sql('SELECT * from test where zoom > %%VAR:var_substitution_1%%', layer, False), 'SELECT * from test where zoom > 14')
         self.assertEqual(to_sql("SELECT * from test where zoom > '%%VAR:var_substitution_2%%'", layer, False), "SELECT * from test where zoom > 'az'")
-        self.assertRaises(KeyError, to_sql, 'SELECT * from test where zoom > %%VAR:var_substitution_3%%', layer, False)
+        self.assertRaises(ValueError, to_sql, 'SELECT * from test where zoom > %%VAR:var_substitution_3%%', layer, False)
 
 
 if __name__ == '__main__':

--- a/tests/python/test_tileset.py
+++ b/tests/python/test_tileset.py
@@ -124,7 +124,6 @@ class TilesTestCase(TestCase):
             self.assertEqual(ts.layers_by_id['my_id'].get_var(k), expected_vars[k])
 
     def test_layer_var(self):
-        self._assert_layer_vars(dict(custom_zoom=None))
         self._assert_layer_vars(dict(custom_zoom='14'),
                                 layer_vars=dict(custom_zoom=14))
         self._assert_layer_vars(dict(custom_zoom='12'),

--- a/tests/python/test_tileset.py
+++ b/tests/python/test_tileset.py
@@ -110,12 +110,12 @@ class TilesTestCase(TestCase):
                        ['c1'], ['a', 'b'], ['x', 'y'], extra)
 
     def _assert_layer_vars(self, expected_vars: dict,
-                           layer_vars: Optional[dict] = None,
+                           layer: Optional[dict] = None,
                            override_ts: Optional[dict] = None,
                            override_layer: Optional[dict] = None,
                            env: Optional[dict] = None):
         ts = self._ts_overrides(
-            dict(vars=layer_vars) if layer_vars is not None else None,
+            dict(vars=layer) if layer is not None else None,
             dict(vars=override_ts) if override_ts is not None else None,
             dict(vars=override_layer) if override_layer is not None else None,
             env)
@@ -125,28 +125,28 @@ class TilesTestCase(TestCase):
 
     def test_layer_var(self):
         self._assert_layer_vars(dict(custom_zoom='14'),
-                                layer_vars=dict(custom_zoom=14))
+                                layer=dict(custom_zoom=14))
         self._assert_layer_vars(dict(custom_zoom='12'),
-                                layer_vars=dict(custom_zoom=14),
+                                layer=dict(custom_zoom=14),
                                 override_layer=dict(custom_zoom=12))
         self._assert_layer_vars(dict(custom_zoom='12'),
-                                layer_vars=dict(custom_zoom=14),
+                                layer=dict(custom_zoom=14),
                                 override_ts=dict(custom_zoom=12))
         self._assert_layer_vars(dict(custom_zoom='13'),
-                                layer_vars=dict(custom_zoom=14),
+                                layer=dict(custom_zoom=14),
                                 override_layer=dict(custom_zoom=13),
                                 override_ts=dict(custom_zoom=12))
+        self._assert_layer_vars(dict(custom_zoom='12'),
+                                layer=dict(custom_zoom=13),
+                                env=dict(OMT_VAR_custom_zoom=12))
         self.assertRaises(ValueError, self._assert_layer_vars,
-                          dict(custom_zoom=None),
-                          layer_vars=dict(),
+                          dict(custom_zoom='-'),
+                          layer=dict(),
                           override_ts=dict(custom_zoom=12))
         self.assertRaises(ValueError, self._assert_layer_vars,
-                          dict(custom_zoom=14),
-                          layer_vars=dict(custom_zoom=14),
+                          dict(custom_zoom='-'),
+                          layer=dict(custom_zoom=14),
                           override_layer=dict(custom_zoom2=12))
-        self._assert_layer_vars(dict(custom_zoom=12),
-                                dict(vars=dict(custom_zoom=13)),
-                                env=dict(OMT_VAR_custom_zoom=12))
 
 
 if __name__ == '__main__':

--- a/tests/python/test_tileset.py
+++ b/tests/python/test_tileset.py
@@ -1,0 +1,106 @@
+import warnings
+from unittest import main, TestCase
+from typing import Optional
+from tests.python.test_helpers import Case, parsed_data
+
+from openmaptiles.tileset import Tileset
+
+
+class TileseTestCase(TestCase):
+    def _ts_overrides(self, expected_layer: dict,
+                      layer: Optional[dict] = None,
+                      override_ts: Optional[dict] = None,
+                      override_layer: Optional[dict] = None,
+                      env: Optional[dict] = None):
+        data = parsed_data([Case('my_id', 'my_query;')])
+
+        ts_data = data.data['tileset']
+        if override_ts is not None:
+            ts_data['overrides'] = override_ts
+        if layer is not None:
+            ts_data['layers'][0]['file'].data['layer'].update(layer)
+        if override_layer is not None:
+            ts_data['layers'][0].update(override_layer)
+
+        ts = Tileset(data, getenv=env.get if env else None)
+        for k in expected_layer.keys():
+            self.assertEqual(getattr(ts.layers_by_id['my_id'], k), expected_layer[k])
+
+    def test_overrides(self):
+        buf_0 = dict(buffer_size=0)
+        buf_1 = dict(buffer_size=1)
+        buf_2 = dict(buffer_size=2)
+        buf_3 = dict(buffer_size=3)
+        min_1 = dict(min_buffer_size=1)
+        min_2 = dict(min_buffer_size=2)
+        min_3 = dict(min_buffer_size=3)
+
+        self._ts_overrides(buf_2, buf_2)
+        self._ts_overrides(buf_0, buf_2, override_ts=buf_0)
+        self._ts_overrides(buf_1, buf_2, override_ts=buf_1)
+        self._ts_overrides(buf_3, buf_2, override_ts=buf_3)
+        self._ts_overrides(buf_1, min_1 | buf_2, override_ts=buf_0)
+        self._ts_overrides(buf_1, buf_2, override_layer=buf_1)
+        self._ts_overrides(buf_2, min_2 | buf_3, override_layer=buf_1)
+        self._ts_overrides(buf_3, min_1 | buf_2, override_layer=min_3)
+        self._ts_overrides(buf_3, min_1 | buf_2, override_layer=min_2 | buf_3, override_ts=buf_0)
+
+        env_0 = dict(TILE_BUFFER_SIZE='0')
+        env_2 = dict(TILE_BUFFER_SIZE='2')
+        self._ts_overrides(buf_2, min_1 | buf_2, override_layer=min_2 | buf_3, override_ts=buf_0, env=env_0)
+        self._ts_overrides(buf_2, buf_1, env=env_2)
+        self._ts_overrides(buf_2, min_2 | buf_3, env=env_0)
+        self._ts_overrides(buf_2, min_1 | buf_3, override_ts=buf_0, env=env_2)
+        self._ts_overrides(buf_2, buf_2, dict(TILE_BUFFER_SIZE=''))
+
+        # str parsing
+        self._ts_overrides(dict(buffer_size=2), dict(buffer_size='2'))
+
+    def _ts_parse(self, reqs, expected_layers, expected_tables, expected_funcs, extra_cases=None):
+        cases = [] if not extra_cases else list(extra_cases)
+        cases.append(Case('my_id', 'my_query;', reqs=reqs))
+        ts = Tileset(parsed_data(cases))
+        self.assertEqual(ts.attribution, 'test_attribution')
+        self.assertEqual(ts.bounds, 'test_bounds')
+        self.assertEqual(ts.center, 'test_center')
+        self.assertEqual(ts.defaults, dict(srs='test_srs', datasource=dict(srid='test_datasource')))
+        self.assertEqual(ts.id, 'id1')
+        self.assertEqual(ts.maxzoom, 'test_maxzoom')
+        self.assertEqual(ts.minzoom, 'test_minzoom')
+        self.assertEqual(ts.name, 'test_name')
+        self.assertEqual(ts.pixel_scale, 'test_pixel_scale')
+        self.assertEqual(ts.version, 'test_version')
+
+        self.assertEqual(len(ts.layers), len(cases))
+        layer = ts.layers_by_id['my_id']
+        self.assertEqual(layer.id, 'my_id')
+        self.assertEqual(layer.requires_layers, expected_layers)
+        self.assertEqual(layer.requires_tables, expected_tables)
+        self.assertEqual(layer.requires_functions, expected_funcs)
+        self.assertEqual(layer.buffer_size, 10)
+
+        # This test can be deleted once we remove the deprecated property in some future version
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', category=DeprecationWarning)
+            self.assertEqual(layer.requires, expected_layers)
+
+    def test_ts_parse(self):
+        extra = [Case('c1', 'SELECT 1;')]
+
+        self._ts_parse(None, [], [], [])
+        self._ts_parse([], [], [], [])
+        self._ts_parse({}, [], [], [])
+        self._ts_parse('c1', ['c1'], [], [], extra)
+        self._ts_parse(['c1'], ['c1'], [], [], extra)
+        self._ts_parse(dict(layers='c1'), ['c1'], [], [], extra)
+        self._ts_parse(dict(layers=['c1']), ['c1'], [], [], extra)
+        self._ts_parse(dict(tables='a'), [], ['a'], [])
+        self._ts_parse(dict(tables=['a', 'b']), [], ['a', 'b'], [])
+        self._ts_parse(dict(functions='x'), [], [], ['x'])
+        self._ts_parse(dict(functions=['x', 'y']), [], [], ['x', 'y'])
+        self._ts_parse(dict(layers=['c1'], tables=['a', 'b'], functions=['x', 'y']),
+                       ['c1'], ['a', 'b'], ['x', 'y'], extra)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/python/test_tileset.py
+++ b/tests/python/test_tileset.py
@@ -6,9 +6,9 @@ from tests.python.test_helpers import Case, parsed_data
 from openmaptiles.tileset import Tileset
 
 
-class TileseTestCase(TestCase):
-    def _ts_overrides(self,
-                      layer: Optional[dict] = None,
+class TilesTestCase(TestCase):
+    @staticmethod
+    def _ts_overrides(layer: Optional[dict] = None,
                       override_ts: Optional[dict] = None,
                       override_layer: Optional[dict] = None,
                       env: Optional[dict] = None):
@@ -110,44 +110,44 @@ class TileseTestCase(TestCase):
                        ['c1'], ['a', 'b'], ['x', 'y'], extra)
 
     def _assert_layer_vars(self, expected_vars: dict,
-                           layer: Optional[dict] = None,
+                           layer_vars: Optional[dict] = None,
                            override_ts: Optional[dict] = None,
                            override_layer: Optional[dict] = None,
                            env: Optional[dict] = None):
-        ts = self._ts_overrides(layer, override_ts, override_layer, env)
+        ts = self._ts_overrides(
+            dict(vars=layer_vars) if layer_vars is not None else None,
+            dict(vars=override_ts) if override_ts is not None else None,
+            dict(vars=override_layer) if override_layer is not None else None,
+            env)
 
         for k in expected_vars.keys():
-            self.assertEqual(ts.layers_by_id['my_id'].vars.get(k), expected_vars[k])
+            self.assertEqual(ts.layers_by_id['my_id'].get_var(k), expected_vars[k])
 
     def test_layer_var(self):
-        data = parsed_data([Case('my_id', 'my_query;')])
-        ts = Tileset(data)
-        self.assertEqual(ts.layers_by_id['my_id'].vars, {})
         self._assert_layer_vars(dict(custom_zoom=None))
-        self._assert_layer_vars(dict(custom_zoom=14),
-                                dict(vars=dict(custom_zoom=14)))
-        self._assert_layer_vars(dict(custom_zoom=12),
-                                dict(vars=dict(custom_zoom=14)),
-                                override_layer=dict(vars=dict(custom_zoom=12)))
-        self._assert_layer_vars(dict(custom_zoom=12),
-                                dict(vars=dict(custom_zoom=14)),
-                                override_ts=dict(vars=dict(custom_zoom=12)))
-        self._assert_layer_vars(dict(custom_zoom=None),
-                                dict(),
-                                override_ts=dict(vars=dict(custom_zoom=12)))
-        self._assert_layer_vars(dict(custom_zoom=13),
-                                dict(vars=dict(custom_zoom=14)),
-                                override_layer=dict(vars=dict(custom_zoom=13)),
-                                override_ts=dict(vars=dict(custom_zoom=12)))
+        self._assert_layer_vars(dict(custom_zoom='14'),
+                                layer_vars=dict(custom_zoom=14))
+        self._assert_layer_vars(dict(custom_zoom='12'),
+                                layer_vars=dict(custom_zoom=14),
+                                override_layer=dict(custom_zoom=12))
+        self._assert_layer_vars(dict(custom_zoom='12'),
+                                layer_vars=dict(custom_zoom=14),
+                                override_ts=dict(custom_zoom=12))
+        self._assert_layer_vars(dict(custom_zoom='13'),
+                                layer_vars=dict(custom_zoom=14),
+                                override_layer=dict(custom_zoom=13),
+                                override_ts=dict(custom_zoom=12))
+        self.assertRaises(ValueError, self._assert_layer_vars,
+                          dict(custom_zoom=None),
+                          layer_vars=dict(),
+                          override_ts=dict(custom_zoom=12))
         self.assertRaises(ValueError, self._assert_layer_vars,
                           dict(custom_zoom=14),
-                          dict(vars=dict(custom_zoom=14)),
-                          override_layer=dict(vars=dict(custom_zoom2=12)))
-
-        env = dict(OMT_VAR_custom_zoom=12)
+                          layer_vars=dict(custom_zoom=14),
+                          override_layer=dict(custom_zoom2=12))
         self._assert_layer_vars(dict(custom_zoom=12),
                                 dict(vars=dict(custom_zoom=13)),
-                                env=env)
+                                env=dict(OMT_VAR_custom_zoom=12))
 
 
 if __name__ == '__main__':

--- a/tests/python/test_tileset.py
+++ b/tests/python/test_tileset.py
@@ -101,6 +101,56 @@ class TileseTestCase(TestCase):
         self._ts_parse(dict(layers=['c1'], tables=['a', 'b'], functions=['x', 'y']),
                        ['c1'], ['a', 'b'], ['x', 'y'], extra)
 
+    def _ts_vars(self, expected_vars: dict,
+                 layer: Optional[dict] = None,
+                 override_ts: Optional[dict] = None,
+                 override_layer: Optional[dict] = None,
+                 env: Optional[dict] = None):
+        data = parsed_data([Case('my_id', 'my_query;')])
+
+        ts_data = data.data['tileset']
+        if override_ts is not None:
+            ts_data['overrides'] = override_ts
+        if layer is not None:
+            ts_data['layers'][0]['file'].data['layer'].update(layer)
+        if override_layer is not None:
+            ts_data['layers'][0].update(override_layer)
+
+        ts = Tileset(data, getenv=env.get if env else None)
+
+        for k in expected_vars.keys():
+            self.assertEqual(ts.layers_by_id['my_id'].vars.get(k), expected_vars[k])
+
+    def test_layer_var(self):
+        data = parsed_data([Case('my_id', 'my_query;')])
+        ts = Tileset(data)
+        self.assertEqual(ts.layers_by_id['my_id'].vars, {})
+        self._ts_vars(dict(custom_zoom=None))
+        self._ts_vars(dict(custom_zoom=14),
+                      dict(vars=dict(custom_zoom=14)))
+        self._ts_vars(dict(custom_zoom=12),
+                      dict(vars=dict(custom_zoom=14)),
+                      override_layer=dict(vars=dict(custom_zoom=12)))
+        self._ts_vars(dict(custom_zoom=12),
+                      dict(vars=dict(custom_zoom=14)),
+                      override_ts=dict(vars=dict(custom_zoom=12)))
+        self._ts_vars(dict(custom_zoom=None),
+                      dict(),
+                      override_ts=dict(vars=dict(custom_zoom=12)))
+        self._ts_vars(dict(custom_zoom=13),
+                      dict(vars=dict(custom_zoom=14)),
+                      override_layer=dict(vars=dict(custom_zoom=13)),
+                      override_ts=dict(vars=dict(custom_zoom=12)))
+        self.assertRaises(ValueError, self._ts_vars,
+                          dict(custom_zoom=14),
+                          dict(vars=dict(custom_zoom=14)),
+                          override_layer=dict(vars=dict(custom_zoom2=12)))
+
+        env = dict(OMT_VAR_custom_zoom=12)
+        self._ts_vars(dict(custom_zoom=12),
+                      dict(vars=dict(custom_zoom=13)),
+                      env=env)
+
 
 if __name__ == '__main__':
     main()

--- a/tests/python/test_tileset.py
+++ b/tests/python/test_tileset.py
@@ -7,7 +7,7 @@ from openmaptiles.tileset import Tileset
 
 
 class TileseTestCase(TestCase):
-    def _ts_overrides(self, expected_layer: dict,
+    def _ts_overrides(self,
                       layer: Optional[dict] = None,
                       override_ts: Optional[dict] = None,
                       override_layer: Optional[dict] = None,
@@ -22,7 +22,15 @@ class TileseTestCase(TestCase):
         if override_layer is not None:
             ts_data['layers'][0].update(override_layer)
 
-        ts = Tileset(data, getenv=env.get if env else None)
+        return Tileset(data, getenv=env.get if env else None)
+
+    def _assert_layer(self, expected_layer: dict,
+                      layer: Optional[dict] = None,
+                      override_ts: Optional[dict] = None,
+                      override_layer: Optional[dict] = None,
+                      env: Optional[dict] = None):
+        ts = self._ts_overrides(layer, override_ts, override_layer, env)
+
         for k in expected_layer.keys():
             self.assertEqual(getattr(ts.layers_by_id['my_id'], k), expected_layer[k])
 
@@ -35,26 +43,26 @@ class TileseTestCase(TestCase):
         min_2 = dict(min_buffer_size=2)
         min_3 = dict(min_buffer_size=3)
 
-        self._ts_overrides(buf_2, buf_2)
-        self._ts_overrides(buf_0, buf_2, override_ts=buf_0)
-        self._ts_overrides(buf_1, buf_2, override_ts=buf_1)
-        self._ts_overrides(buf_3, buf_2, override_ts=buf_3)
-        self._ts_overrides(buf_1, min_1 | buf_2, override_ts=buf_0)
-        self._ts_overrides(buf_1, buf_2, override_layer=buf_1)
-        self._ts_overrides(buf_2, min_2 | buf_3, override_layer=buf_1)
-        self._ts_overrides(buf_3, min_1 | buf_2, override_layer=min_3)
-        self._ts_overrides(buf_3, min_1 | buf_2, override_layer=min_2 | buf_3, override_ts=buf_0)
+        self._assert_layer(buf_2, buf_2)
+        self._assert_layer(buf_0, buf_2, override_ts=buf_0)
+        self._assert_layer(buf_1, buf_2, override_ts=buf_1)
+        self._assert_layer(buf_3, buf_2, override_ts=buf_3)
+        self._assert_layer(buf_1, min_1 | buf_2, override_ts=buf_0)
+        self._assert_layer(buf_1, buf_2, override_layer=buf_1)
+        self._assert_layer(buf_2, min_2 | buf_3, override_layer=buf_1)
+        self._assert_layer(buf_3, min_1 | buf_2, override_layer=min_3)
+        self._assert_layer(buf_3, min_1 | buf_2, override_layer=min_2 | buf_3, override_ts=buf_0)
 
         env_0 = dict(TILE_BUFFER_SIZE='0')
         env_2 = dict(TILE_BUFFER_SIZE='2')
-        self._ts_overrides(buf_2, min_1 | buf_2, override_layer=min_2 | buf_3, override_ts=buf_0, env=env_0)
-        self._ts_overrides(buf_2, buf_1, env=env_2)
-        self._ts_overrides(buf_2, min_2 | buf_3, env=env_0)
-        self._ts_overrides(buf_2, min_1 | buf_3, override_ts=buf_0, env=env_2)
-        self._ts_overrides(buf_2, buf_2, dict(TILE_BUFFER_SIZE=''))
+        self._assert_layer(buf_2, min_1 | buf_2, override_layer=min_2 | buf_3, override_ts=buf_0, env=env_0)
+        self._assert_layer(buf_2, buf_1, env=env_2)
+        self._assert_layer(buf_2, min_2 | buf_3, env=env_0)
+        self._assert_layer(buf_2, min_1 | buf_3, override_ts=buf_0, env=env_2)
+        self._assert_layer(buf_2, buf_2, dict(TILE_BUFFER_SIZE=''))
 
         # str parsing
-        self._ts_overrides(dict(buffer_size=2), dict(buffer_size='2'))
+        self._assert_layer(dict(buffer_size=2), dict(buffer_size='2'))
 
     def _ts_parse(self, reqs, expected_layers, expected_tables, expected_funcs, extra_cases=None):
         cases = [] if not extra_cases else list(extra_cases)
@@ -101,22 +109,12 @@ class TileseTestCase(TestCase):
         self._ts_parse(dict(layers=['c1'], tables=['a', 'b'], functions=['x', 'y']),
                        ['c1'], ['a', 'b'], ['x', 'y'], extra)
 
-    def _ts_vars(self, expected_vars: dict,
-                 layer: Optional[dict] = None,
-                 override_ts: Optional[dict] = None,
-                 override_layer: Optional[dict] = None,
-                 env: Optional[dict] = None):
-        data = parsed_data([Case('my_id', 'my_query;')])
-
-        ts_data = data.data['tileset']
-        if override_ts is not None:
-            ts_data['overrides'] = override_ts
-        if layer is not None:
-            ts_data['layers'][0]['file'].data['layer'].update(layer)
-        if override_layer is not None:
-            ts_data['layers'][0].update(override_layer)
-
-        ts = Tileset(data, getenv=env.get if env else None)
+    def _assert_layer_vars(self, expected_vars: dict,
+                           layer: Optional[dict] = None,
+                           override_ts: Optional[dict] = None,
+                           override_layer: Optional[dict] = None,
+                           env: Optional[dict] = None):
+        ts = self._ts_overrides(layer, override_ts, override_layer, env)
 
         for k in expected_vars.keys():
             self.assertEqual(ts.layers_by_id['my_id'].vars.get(k), expected_vars[k])
@@ -125,31 +123,31 @@ class TileseTestCase(TestCase):
         data = parsed_data([Case('my_id', 'my_query;')])
         ts = Tileset(data)
         self.assertEqual(ts.layers_by_id['my_id'].vars, {})
-        self._ts_vars(dict(custom_zoom=None))
-        self._ts_vars(dict(custom_zoom=14),
-                      dict(vars=dict(custom_zoom=14)))
-        self._ts_vars(dict(custom_zoom=12),
-                      dict(vars=dict(custom_zoom=14)),
-                      override_layer=dict(vars=dict(custom_zoom=12)))
-        self._ts_vars(dict(custom_zoom=12),
-                      dict(vars=dict(custom_zoom=14)),
-                      override_ts=dict(vars=dict(custom_zoom=12)))
-        self._ts_vars(dict(custom_zoom=None),
-                      dict(),
-                      override_ts=dict(vars=dict(custom_zoom=12)))
-        self._ts_vars(dict(custom_zoom=13),
-                      dict(vars=dict(custom_zoom=14)),
-                      override_layer=dict(vars=dict(custom_zoom=13)),
-                      override_ts=dict(vars=dict(custom_zoom=12)))
-        self.assertRaises(ValueError, self._ts_vars,
+        self._assert_layer_vars(dict(custom_zoom=None))
+        self._assert_layer_vars(dict(custom_zoom=14),
+                                dict(vars=dict(custom_zoom=14)))
+        self._assert_layer_vars(dict(custom_zoom=12),
+                                dict(vars=dict(custom_zoom=14)),
+                                override_layer=dict(vars=dict(custom_zoom=12)))
+        self._assert_layer_vars(dict(custom_zoom=12),
+                                dict(vars=dict(custom_zoom=14)),
+                                override_ts=dict(vars=dict(custom_zoom=12)))
+        self._assert_layer_vars(dict(custom_zoom=None),
+                                dict(),
+                                override_ts=dict(vars=dict(custom_zoom=12)))
+        self._assert_layer_vars(dict(custom_zoom=13),
+                                dict(vars=dict(custom_zoom=14)),
+                                override_layer=dict(vars=dict(custom_zoom=13)),
+                                override_ts=dict(vars=dict(custom_zoom=12)))
+        self.assertRaises(ValueError, self._assert_layer_vars,
                           dict(custom_zoom=14),
                           dict(vars=dict(custom_zoom=14)),
                           override_layer=dict(vars=dict(custom_zoom2=12)))
 
         env = dict(OMT_VAR_custom_zoom=12)
-        self._ts_vars(dict(custom_zoom=12),
-                      dict(vars=dict(custom_zoom=13)),
-                      env=env)
+        self._assert_layer_vars(dict(custom_zoom=12),
+                                dict(vars=dict(custom_zoom=13)),
+                                env=env)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Made a few changes that i think will simplify things:
* easier to remove all those init functions - they would just confuse things and are far more verbose - harder to read
  * btw, the double underscore should not be used in code - its reserved for the python built-in methods
* handle VAR and FIELD_MAPPING with the same regex
* Minor breaking change:  don't allow "-" symbol in the variable names (not used in OMT anyway)